### PR TITLE
refactor!: simplify identity configuration

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -97,15 +97,16 @@ variable "application_stack" {
   default = null
 }
 
-variable "identity" {
-  description = "The identity or identities to configure for this Function App."
+variable "system_assigned_identity_enabled" {
+  description = "Should the system-assigned identity be enabled for this Web App?"
+  type        = bool
+  default     = false
+}
 
-  type = object({
-    type         = optional(string, "SystemAssigned")
-    identity_ids = optional(list(string), [])
-  })
-
-  default = null
+variable "identity_ids" {
+  description = "A list of IDs of managed identities to be assigned to this Web App."
+  type        = list(string)
+  default     = []
 }
 
 variable "tags" {


### PR DESCRIPTION
BREAKING CHANGE: remove variable `identity`, add variables `system_assigned_identity_enabled` and `identity_ids`.