### PR TITLE
feat!: split application stack properties into variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    name: Unit Tests
+    uses: equinor/terraform-baseline/.github/workflows/terraform-test.yml@main
+    with:
+      test-filter: tests/unit.tftest.hcl

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,12 @@ locals {
   identity_type = join(", ", compact([var.system_assigned_identity_enabled ? "SystemAssigned" : "", length(local.identity_ids) > 0 ? "UserAssigned" : ""]))
 
   diagnostic_setting_metric_categories = ["AllMetrics"]
+
+  dotnet_application_stack          = var.application_stack_dotnet_version != null ? [0] : []
+  java_application_stack            = var.application_stack_java_version != null ? [0] : []
+  node_application_stack            = var.application_stack_node_version != null ? [0] : []
+  python_application_stack          = var.application_stack_python_version != null ? [0] : []
+  powershell_core_application_stack = var.application_stack_powershell_core_version != null ? [0] : []
 }
 
 resource "azurerm_linux_function_app" "this" {
@@ -43,16 +49,43 @@ resource "azurerm_linux_function_app" "this" {
     app_scale_limit                        = var.app_scale_limit
 
     dynamic "application_stack" {
-      for_each = var.application_stack != null ? [var.application_stack] : []
+      for_each = local.dotnet_application_stack
 
       content {
-        dotnet_version              = application_stack.value["dotnet_version"]
-        use_dotnet_isolated_runtime = application_stack.value["use_dotnet_isolated_runtime"]
-        java_version                = application_stack.value["java_version"]
-        node_version                = application_stack.value["node_version"]
-        python_version              = application_stack.value["python_version"]
-        powershell_core_version     = application_stack.value["powershell_core_version"]
-        use_custom_runtime          = application_stack.value["use_custom_runtime"]
+        dotnet_version              = var.application_stack_dotnet_version
+        use_dotnet_isolated_runtime = var.application_stack_use_dotnet_isolated_runtime
+      }
+    }
+
+    dynamic "application_stack" {
+      for_each = local.java_application_stack
+
+      content {
+        java_version = var.application_stack_java_version
+      }
+    }
+
+    dynamic "application_stack" {
+      for_each = local.node_application_stack
+
+      content {
+        node_version = var.application_stack_node_version
+      }
+    }
+
+    dynamic "application_stack" {
+      for_each = local.python_application_stack
+
+      content {
+        python_version = var.application_stack_python_version
+      }
+    }
+
+    dynamic "application_stack" {
+      for_each = local.powershell_core_application_stack
+
+      content {
+        powershell_core_version = var.application_stack_powershell_core_version
       }
     }
   }
@@ -78,6 +111,18 @@ resource "azurerm_linux_function_app" "this" {
       tags["hidden-link: /app-insights-conn-string"],
       tags["hidden-link: /app-insights-resource-id"]
     ]
+
+    precondition {
+      condition = length(compact([
+        var.application_stack_dotnet_version,
+        var.application_stack_java_version,
+        var.application_stack_node_version,
+        var.application_stack_python_version,
+        var.application_stack_powershell_core_version
+      ])) < 2
+
+      error_message = "Multiple application stacks are defined. Number of application stacks defined can only be one or null."
+    }
   }
 }
 
@@ -111,15 +156,35 @@ resource "azurerm_windows_function_app" "this" {
     app_scale_limit                        = var.app_scale_limit
 
     dynamic "application_stack" {
-      for_each = var.application_stack != null ? [var.application_stack] : []
+      for_each = local.dotnet_application_stack
 
       content {
-        dotnet_version              = application_stack.value["dotnet_version"]
-        use_dotnet_isolated_runtime = application_stack.value["use_dotnet_isolated_runtime"]
-        java_version                = application_stack.value["java_version"]
-        node_version                = application_stack.value["node_version"]
-        powershell_core_version     = application_stack.value["powershell_core_version"]
-        use_custom_runtime          = application_stack.value["use_custom_runtime"]
+        dotnet_version              = var.application_stack_dotnet_version
+        use_dotnet_isolated_runtime = var.application_stack_use_dotnet_isolated_runtime
+      }
+    }
+
+    dynamic "application_stack" {
+      for_each = local.java_application_stack
+
+      content {
+        java_version = var.application_stack_java_version
+      }
+    }
+
+    dynamic "application_stack" {
+      for_each = local.node_application_stack
+
+      content {
+        node_version = var.application_stack_node_version
+      }
+    }
+
+    dynamic "application_stack" {
+      for_each = local.powershell_core_application_stack
+
+      content {
+        powershell_core_version = var.application_stack_powershell_core_version
       }
     }
   }
@@ -145,6 +210,17 @@ resource "azurerm_windows_function_app" "this" {
       tags["hidden-link: /app-insights-conn-string"],
       tags["hidden-link: /app-insights-resource-id"]
     ]
+
+    precondition {
+      condition = length(compact([
+        var.application_stack_dotnet_version,
+        var.application_stack_java_version,
+        var.application_stack_node_version,
+        var.application_stack_powershell_core_version
+      ])) < 2
+
+      error_message = "Multiple application stacks are defined. Number of application stacks defined can only be one or null."
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,8 @@ resource "azurerm_linux_function_app" "this" {
       tags["hidden-link: /app-insights-resource-id"]
     ]
 
+    # Precondition to verify only one or null application stacks are defined.
+    # Multiple defined stacks creates a conflict.
     precondition {
       condition = length(compact([
         var.application_stack_dotnet_version,
@@ -211,6 +213,8 @@ resource "azurerm_windows_function_app" "this" {
       tags["hidden-link: /app-insights-resource-id"]
     ]
 
+    # Precondition to verify only one or null application stacks are defined.
+    # Multiple defined stacks creates a conflict.
     precondition {
       condition = length(compact([
         var.application_stack_dotnet_version,

--- a/tests/setup-unit-tests/main.tf
+++ b/tests/setup-unit-tests/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6.0"
+    }
+  }
+}
+
+resource "random_id" "name_suffix" {
+  byte_length = 8
+}
+
+resource "random_uuid" "subscription_id" {}
+
+locals {
+  name_suffix         = random_id.name_suffix.hex
+  subscription_id     = random_uuid.subscription_id.result
+  resource_group_name = "rg-${local.name_suffix}"
+  app_name            = "func-${local.name_suffix}"
+  app_service_plan_id = "/subscriptions/${random_uuid.subscription_id.result}/resourceGroups/${local.resource_group_name}/providers/Microsoft.Web/serverFarms/asp-${local.name_suffix}"
+}

--- a/tests/setup-unit-tests/outputs.tf
+++ b/tests/setup-unit-tests/outputs.tf
@@ -1,0 +1,27 @@
+output "app_name" {
+  value = local.app_name
+}
+
+output "resource_group_name" {
+  value = local.resource_group_name
+}
+
+output "location" {
+  value = "northeurope"
+}
+
+output "app_service_plan_id" {
+  value = local.app_service_plan_id
+}
+
+output "storage_account_name" {
+  value = "stfunc${local.name_suffix}"
+}
+
+output "storage_account_key" {
+  value = random_uuid.subscription_id.result
+}
+
+output "log_analytics_workspace_id" {
+  value = "/subscriptions/${random_uuid.subscription_id.result}/resourceGroups/${local.resource_group_name}/providers/Microsoft.OperationalInsights/workspaces/log-${local.name_suffix}"
+}

--- a/tests/unit.tftest.hcl
+++ b/tests/unit.tftest.hcl
@@ -1,0 +1,56 @@
+mock_provider "azurerm" {}
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup-unit-tests"
+  }
+}
+
+run "linux_app" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    storage_account_name       = run.setup_tests.storage_account_name
+    storage_account_key        = run.setup_tests.storage_account_key
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+  }
+
+  assert {
+    condition     = length(azurerm_linux_function_app.this) == 1
+    error_message = "Linux Function App not created"
+  }
+
+  assert {
+    condition     = length(azurerm_windows_function_app.this) == 0
+    error_message = "Trying to create Windows Function App"
+  }
+}
+
+run "windows_app" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    kind                       = "Windows"
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    storage_account_name       = run.setup_tests.storage_account_name
+    storage_account_key        = run.setup_tests.storage_account_key
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+  }
+
+  assert {
+    condition     = length(azurerm_windows_function_app.this) == 1
+    error_message = "Windows Function App not created"
+  }
+
+  assert {
+    condition     = length(azurerm_linux_function_app.this) == 0
+    error_message = "Trying to create Linux Function App"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -111,20 +111,56 @@ variable "app_scale_limit" {
   default     = 1
 }
 
-variable "application_stack" {
-  description = "The application stack to configure for this Function App."
+# variable "application_stack" {
+#   description = "The application stack to configure for this Function App."
 
-  type = object({
-    dotnet_version              = optional(string)
-    use_dotnet_isolated_runtime = optional(bool, false)
-    java_version                = optional(string)
-    node_version                = optional(string)
-    python_version              = optional(string)
-    powershell_core_version     = optional(string)
-    use_custom_runtime          = optional(bool)
-  })
+#   type = object({
+#     dotnet_version              = optional(string)
+#     use_dotnet_isolated_runtime = optional(bool, false)
+#     java_version                = optional(string)
+#     node_version                = optional(string)
+#     python_version              = optional(string)
+#     powershell_core_version     = optional(string)
+#     use_custom_runtime          = optional(bool)
+#   })
 
-  default = null
+#   default = null
+# }
+
+variable "application_stack_dotnet_version" {
+  description = "The version of .NET to use for this Fuction App."
+  type        = string
+  default     = null
+}
+
+variable "application_stack_use_dotnet_isolated_runtime" {
+  description = "Should the .NET process for this Function App use an isolated runtime?"
+  type        = bool
+  default     = false
+}
+
+variable "application_stack_java_version" {
+  description = "The version of Java to use for this Fuction App."
+  type        = string
+  default     = null
+}
+
+variable "application_stack_node_version" {
+  description = "The version of Node to use for this Fuction App."
+  type        = string
+  default     = null
+}
+
+variable "application_stack_python_version" {
+  description = "The version of Puthon to use for this Fuction App."
+  type        = string
+  default     = null
+}
+
+variable "application_stack_powershell_core_version" {
+  description = "The version of PowerShell Core to use for this Fuction App."
+  type        = string
+  default     = null
 }
 
 variable "system_assigned_identity_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -111,24 +111,8 @@ variable "app_scale_limit" {
   default     = 1
 }
 
-# variable "application_stack" {
-#   description = "The application stack to configure for this Function App."
-
-#   type = object({
-#     dotnet_version              = optional(string)
-#     use_dotnet_isolated_runtime = optional(bool, false)
-#     java_version                = optional(string)
-#     node_version                = optional(string)
-#     python_version              = optional(string)
-#     powershell_core_version     = optional(string)
-#     use_custom_runtime          = optional(bool)
-#   })
-
-#   default = null
-# }
-
 variable "application_stack_dotnet_version" {
-  description = "The version of .NET to use for this Fuction App."
+  description = "The version of .NET to use for this Function App."
   type        = string
   default     = null
 }
@@ -140,25 +124,25 @@ variable "application_stack_use_dotnet_isolated_runtime" {
 }
 
 variable "application_stack_java_version" {
-  description = "The version of Java to use for this Fuction App."
+  description = "The version of Java to use for this Function App."
   type        = string
   default     = null
 }
 
 variable "application_stack_node_version" {
-  description = "The version of Node to use for this Fuction App."
+  description = "The version of Node.js to use for this Function App."
   type        = string
   default     = null
 }
 
 variable "application_stack_python_version" {
-  description = "The version of Puthon to use for this Fuction App."
+  description = "The version of Python to use for this Function App."
   type        = string
   default     = null
 }
 
 variable "application_stack_powershell_core_version" {
-  description = "The version of PowerShell Core to use for this Fuction App."
+  description = "The version of PowerShell Core to use for this Function App."
   type        = string
   default     = null
 }


### PR DESCRIPTION
## BREAKING CHANGE

- Variable `application_stack` has been removed.
- Option to set application stack `use_custom_runtime` has been removed.
- Variable `application_stack_dotnet_version` has been added.
- Variable `application_stack_use_dotnet_isolated_runtime` has been added.
- Variable `application_stack_java_version` has been added.
- Variable `application_stack_node_version` has been added.
- Variable `application_stack_python_version` has been added.
- Variable `application_stack_powershell_core_version` has been added.


### Checklist

- [x] I've updated both the `azurerm_linux_function_app` and `azurerm_windows_function_app` resources.
