### PR TITLE
feat!: configure app settings

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,27 @@ variable "log_analytics_workspace_id" {
   type        = string
 }
 
+variable "app_settings" {
+  description = "A map of app settings to be configured for this Function App."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+
+  validation {
+    condition     = length(setintersection(["AzureWebJobsDashboard__accountName", "AzureWebJobsStorage__accountName"], keys(var.app_settings))) == 0
+    error_message = "Storage settings (\"AzureWebJobs*\") must be configured using \"storage_account_id\"."
+  }
+
+  validation {
+    condition     = length(setintersection(["FUNCTIONS_EXTENSION_VERSION"], keys(var.app_settings))) == 0
+    error_message = "Functions extension version (\"FUNCTIONS_EXTENSION_VERSION*\") must be configured using \"functions_extension_version\"."
+  }
+}
+
+variable "functions_extension_version" {
+  default = "~4"
+}
+
 variable "diagnostic_setting_name" {
   description = "The name of this diagnostic setting."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -36,17 +36,20 @@ variable "app_settings" {
 
   validation {
     condition     = length(setintersection(["AzureWebJobsDashboard__accountName", "AzureWebJobsStorage__accountName"], keys(var.app_settings))) == 0
-    error_message = "Storage settings (\"AzureWebJobs*\") must be configured using \"storage_account_id\"."
+    error_message = "Storage account must be configured using the \"storage_account_id\" variable."
   }
 
   validation {
     condition     = length(setintersection(["FUNCTIONS_EXTENSION_VERSION"], keys(var.app_settings))) == 0
-    error_message = "Functions extension version (\"FUNCTIONS_EXTENSION_VERSION*\") must be configured using \"functions_extension_version\"."
+    error_message = "Functions extension version must be configured using the \"functions_extension_version\" variable."
   }
 }
 
 variable "functions_extension_version" {
-  default = "~4"
+  description = "Which extension version to use for this Function App."
+  type        = string
+  default     = "~4"
+  nullable    = false
 }
 
 variable "diagnostic_setting_name" {


### PR DESCRIPTION
BREAKING CHANGE: changes to app settings will no longer be ignored. To migrate your project, configure app settings for your Function App using the new `app_settings` variable. Consider using App Configuration and Key Vault references to continue managing settings outside of Terraform.
