### PR TITLE
feat!: deny public network access by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,21 @@ resource "azurerm_linux_function_app" "this" {
     pre_warmed_instance_count              = var.pre_warmed_instance_count
     app_scale_limit                        = var.app_scale_limit
     use_32_bit_worker                      = var.use_32_bit_worker
+    ip_restriction_default_action          = var.ip_restriction_default_action
+    scm_ip_restriction_default_action      = var.scm_ip_restriction_default_action
+
+    dynamic "ip_restriction" {
+      for_each = var.ip_restrictions
+
+      content {
+        action      = ip_restriction.value.action
+        headers     = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+        ip_address  = ip_restriction.value.ip_address
+        name        = ip_restriction.value.name
+        priority    = ip_restriction.value.priority
+        service_tag = ip_restriction.value.service_tag
+      }
+    }
 
     dynamic "application_stack" {
       for_each = local.dotnet_application_stack
@@ -157,6 +172,21 @@ resource "azurerm_windows_function_app" "this" {
     pre_warmed_instance_count              = var.pre_warmed_instance_count
     app_scale_limit                        = var.app_scale_limit
     use_32_bit_worker                      = var.use_32_bit_worker
+    ip_restriction_default_action          = var.ip_restriction_default_action
+    scm_ip_restriction_default_action      = var.scm_ip_restriction_default_action
+
+    dynamic "ip_restriction" {
+      for_each = var.ip_restrictions
+
+      content {
+        action      = ip_restriction.value.action
+        headers     = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+        ip_address  = ip_restriction.value.ip_address
+        name        = ip_restriction.value.name
+        priority    = ip_restriction.value.priority
+        service_tag = ip_restriction.value.service_tag
+      }
+    }
 
     dynamic "application_stack" {
       for_each = local.dotnet_application_stack

--- a/variables.tf
+++ b/variables.tf
@@ -171,6 +171,51 @@ variable "use_32_bit_worker" {
   default     = true
 }
 
+variable "ip_restriction_default_action" {
+  description = "The default action for traffic that does not match any IP restriction rule. Value must be \"Allow\" or \"Deny\"."
+  type        = string
+  default     = "Deny"
+  nullable    = false
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.ip_restriction_default_action)
+    error_message = "IP restriction default action must be \"Allow\" or \"Deny\"."
+  }
+}
+
+variable "scm_ip_restriction_default_action" {
+  description = "The default action for traffic to the Source Control Manager (SCM) that does not match any IP restriction rule. Value must be \"Allow\" or \"Deny\"."
+  type        = string
+  default     = "Deny"
+  nullable    = false
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.scm_ip_restriction_default_action)
+    error_message = "SCM IP restriction default action must be \"Allow\" or \"Deny\"."
+  }
+}
+
+variable "ip_restrictions" {
+  description = "A list of IP restrictions to be configured for this Function App."
+
+  type = list(object({
+    action      = optional(string, "Allow")
+    ip_address  = optional(string)
+    name        = string
+    priority    = number
+    service_tag = optional(string)
+
+    headers = optional(object({
+      x_forwarded_for   = optional(list(string))
+      x_forwarded_host  = optional(list(string))
+      x_azure_fdid      = optional(list(string))
+      x_fd_health_probe = optional(list(string))
+    }))
+  }))
+
+  default = []
+}
+
 variable "identity_ids" {
   description = "A list of IDs of managed identities to be assigned to this Web App."
   type        = list(string)


### PR DESCRIPTION
BREAKING CHANGE: public network access denied by default. To keep public network access allowed by default, set the value of variables `ip_restriction_default_action` and `scm_ip_restriction_default_action` to `"Allow"`.