### PR TITLE
feat: configure FTPS state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ resource "azurerm_linux_function_app" "this" {
     use_32_bit_worker                 = var.use_32_bit_worker
     ip_restriction_default_action     = var.ip_restriction_default_action
     scm_ip_restriction_default_action = var.scm_ip_restriction_default_action
+    ftps_state                        = var.ftps_state
 
     dynamic "ip_restriction" {
       for_each = var.ip_restrictions
@@ -177,6 +178,7 @@ resource "azurerm_windows_function_app" "this" {
     use_32_bit_worker                 = var.use_32_bit_worker
     ip_restriction_default_action     = var.ip_restriction_default_action
     scm_ip_restriction_default_action = var.scm_ip_restriction_default_action
+    ftps_state                        = var.ftps_state
 
     dynamic "ip_restriction" {
       for_each = var.ip_restrictions

--- a/tests/configuration.unit.tftest.hcl
+++ b/tests/configuration.unit.tftest.hcl
@@ -111,3 +111,123 @@ run "windows_basic_authentication_enabled" {
     error_message = "Basic authentication disabled for the WebDeploy client."
   }
 }
+
+run "linux_ftps_state_disabled" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    storage_account_id         = run.setup_tests.storage_account_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    ftps_state = "Disabled"
+  }
+
+  assert {
+    condition = azurerm_linux_function_app.this[0].site_config[0].ftps_state == "Disabled"
+    error_message = "FTPS state is \"AllAllowed\", or \"FtpsOnly\"."
+  }
+}
+
+run "linux_ftps_state_ftpsonly" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    storage_account_id         = run.setup_tests.storage_account_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    ftps_state = "FtpsOnly"
+  }
+
+  assert {
+    condition = azurerm_linux_function_app.this[0].site_config[0].ftps_state == "FtpsOnly"
+    error_message = "FTPS state is \"AllAllowed\", or \"Disabled\"."
+  }
+}
+
+run "linux_ftps_state_allallowed" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    storage_account_id         = run.setup_tests.storage_account_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    ftps_state = "AllAllowed"
+  }
+
+  assert {
+    condition = azurerm_linux_function_app.this[0].site_config[0].ftps_state == "AllAllowed"
+    error_message = "FTPS state is \"FtpsOnly\", or \"Disabled\"."
+  }
+}
+
+run "windows_ftps_state_disabled" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    storage_account_id         = run.setup_tests.storage_account_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    ftps_state = "Disabled"
+  }
+
+  assert {
+    condition = azurerm_windows_function_app.this[0].site_config[0].ftps_state == "Disabled"
+    error_message = "FTPS state is \"AllAllowed\", or \"FtpsOnly\"."
+  }
+}
+
+run "windows_ftps_state_ftpsonly" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    storage_account_id         = run.setup_tests.storage_account_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    ftps_state = "FtpsOnly"
+  }
+
+  assert {
+    condition = azurerm_windows_function_app.this[0].site_config[0].ftps_state == "FtpsOnly"
+    error_message = "FTPS state is \"AllAllowed\", or \"Disabled\"."
+  }
+}
+
+run "windows_ftps_state_allallowed" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    storage_account_id         = run.setup_tests.storage_account_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    ftps_state = "AllAllowed"
+  }
+
+  assert {
+    condition = azurerm_windows_function_app.this[0].site_config[0].ftps_state == "AllAllowd"
+    error_message = "FTPS state is \"FtpsOnly\", or \"Disabled\"."
+  }
+}

--- a/tests/configuration.unit.tftest.hcl
+++ b/tests/configuration.unit.tftest.hcl
@@ -179,6 +179,7 @@ run "windows_ftps_state_disabled" {
     app_name                   = run.setup_tests.app_name
     resource_group_name        = run.setup_tests.resource_group_name
     location                   = run.setup_tests.location
+    kind                       = "Windows"
     app_service_plan_id        = run.setup_tests.app_service_plan_id
     storage_account_id         = run.setup_tests.storage_account_id
     log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
@@ -199,6 +200,7 @@ run "windows_ftps_state_ftpsonly" {
     app_name                   = run.setup_tests.app_name
     resource_group_name        = run.setup_tests.resource_group_name
     location                   = run.setup_tests.location
+    kind                       = "Windows"
     app_service_plan_id        = run.setup_tests.app_service_plan_id
     storage_account_id         = run.setup_tests.storage_account_id
     log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
@@ -219,6 +221,7 @@ run "windows_ftps_state_allallowed" {
     app_name                   = run.setup_tests.app_name
     resource_group_name        = run.setup_tests.resource_group_name
     location                   = run.setup_tests.location
+    kind                       = "Windows"
     app_service_plan_id        = run.setup_tests.app_service_plan_id
     storage_account_id         = run.setup_tests.storage_account_id
     log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
@@ -227,7 +230,7 @@ run "windows_ftps_state_allallowed" {
   }
 
   assert {
-    condition = azurerm_windows_function_app.this[0].site_config[0].ftps_state == "AllAllowd"
+    condition = azurerm_windows_function_app.this[0].site_config[0].ftps_state == "AllAllowed"
     error_message = "FTPS state is \"FtpsOnly\", or \"Disabled\"."
   }
 }

--- a/tests/defaults.unit.tftest.hcl
+++ b/tests/defaults.unit.tftest.hcl
@@ -37,10 +37,11 @@ run "linux_app" {
     condition     = azurerm_linux_function_app.this[0].webdeploy_publish_basic_authentication_enabled == false
     error_message = "Basic authentication enabled for the WebDeploy client."
   }
-  
+
   assert {
     condition = azurerm_linux_function_app.this[0].site_config[0].ftps_state == "Disabled"
     error_message = "FTPS state is \"AllAllowed\", or \"FtpsOnly\"."
+  }
 
   assert {
     condition = azurerm_linux_function_app.this[0].builtin_logging_enabled == false
@@ -84,6 +85,7 @@ run "windows_app" {
   assert {
     condition = azurerm_windows_function_app.this[0].site_config[0].ftps_state == "Disabled"
     error_message = "FTPS state is \"AllAllowed\", or \"FtpsOnly\"."
+  }
 
   assert {
     condition = azurerm_windows_function_app.this[0].builtin_logging_enabled == false

--- a/tests/defaults.unit.tftest.hcl
+++ b/tests/defaults.unit.tftest.hcl
@@ -37,6 +37,10 @@ run "linux_app" {
     condition     = azurerm_linux_function_app.this[0].webdeploy_publish_basic_authentication_enabled == false
     error_message = "Basic authentication enabled for the WebDeploy client."
   }
+  assert {
+    condition = azurerm_linux_function_app.this[0].site_config[0].ftps_state == "Disabled"
+    error_message = "FTPS state is \"AllAllowed\", or \"FtpsOnly\"."
+  }
 }
 
 run "windows_app" {
@@ -70,5 +74,9 @@ run "windows_app" {
   assert {
     condition     = azurerm_windows_function_app.this[0].webdeploy_publish_basic_authentication_enabled == false
     error_message = "Basic authentication enabled for the WebDeploy client."
+  }
+  assert {
+    condition = azurerm_windows_function_app.this[0].site_config[0].ftps_state == "Disabled"
+    error_message = "FTPS state is \"AllAllowed\", or \"FtpsOnly\"."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -225,6 +225,7 @@ variable "ftps_state" {
     condition     = contains(["AllAllowed", "FtpsOnly", "Disabled"], var.ftps_state)
     error_message = "FTPS state must be \"AllAllowed\", \"FtpsOnly\" or \"Disabled\"."
   }
+}
 
 variable "ftp_publish_basic_authentication_enabled" {
   description = "Should basic (username and password) authentication be enabled for the FTP client?"

--- a/variables.tf
+++ b/variables.tf
@@ -220,6 +220,11 @@ variable "ftps_state" {
   description = "The state of the FTP / FTPS service for this Function App. Value must be \"AllAllowed\", \"FtpsOnly\" or \"Disabled\"."
   type        = string
   default     = "Disabled"
+  
+  validation {
+    condition     = contains(["AllAllowed", "FtpsOnly", "Disabled"], var.ftps_state)
+    error_message = "FTPS state must be \"AllAllowed\", \"FtpsOnly\" or \"Disabled\"."
+  }
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -216,6 +216,12 @@ variable "identity_ids" {
   default     = []
 }
 
+variable "ftps_state" {
+  description = "State of FTP/FTPS service for this Windows Function App."
+  type        = string
+  default     = "Disabled"
+}
+
 variable "tags" {
   description = "A map of tags to assign to the resources."
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -220,7 +220,7 @@ variable "ftps_state" {
   description = "The state of the FTP / FTPS service for this Function App. Value must be \"AllAllowed\", \"FtpsOnly\" or \"Disabled\"."
   type        = string
   default     = "Disabled"
-  
+
   validation {
     condition     = contains(["AllAllowed", "FtpsOnly", "Disabled"], var.ftps_state)
     error_message = "FTPS state must be \"AllAllowed\", \"FtpsOnly\" or \"Disabled\"."

--- a/variables.tf
+++ b/variables.tf
@@ -217,7 +217,7 @@ variable "identity_ids" {
 }
 
 variable "ftps_state" {
-  description = "State of FTP/FTPS service for this Windows Function App."
+  description = "The state of the FTP / FTPS service for this Function App. Value must be \"AllAllowed\", \"FtpsOnly\" or \"Disabled\"."
   type        = string
   default     = "Disabled"
 }


### PR DESCRIPTION
### Checklist

- [x] I've updated both the `azurerm_linux_function_app` and `azurerm_windows_function_app` resources.

Test passed 🎆  

But i have a question for @equinor/terraform-baseline-maintainers, according to this [FTPS](https://learn.microsoft.com/en-us/azure/app-service/deploy-ftp?tabs=portal#enforce-ftps) we can just disable (as i have it by default) both FTP and FTPS if we are not using FTP deployment. But if we want enchanced security, we should allow FTP over TLS/SSL. Do you guys have any thoughs about this ?