### PR TITLE
chore: clarify why built-in logging is disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,10 @@ locals {
 
   storage_account_name = provider::azurerm::parse_resource_id(var.storage_account_id).resource_name
 
+  # Built-in monitoring is no longer recommended. Use Application Insights instead.
+  # Ref: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring#disable-built-in-logging
+  builtin_logging_enabled = false
+
   # Auto assign Key Vault reference identity
   identity_ids = concat(compact([var.key_vault_reference_identity_id]), var.identity_ids)
 
@@ -37,7 +41,7 @@ resource "azurerm_linux_function_app" "this" {
   ftp_publish_basic_authentication_enabled       = var.ftp_publish_basic_authentication_enabled
   webdeploy_publish_basic_authentication_enabled = var.webdeploy_publish_basic_authentication_enabled
 
-  builtin_logging_enabled = false
+  builtin_logging_enabled = local.builtin_logging_enabled
 
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
 
@@ -169,7 +173,7 @@ resource "azurerm_windows_function_app" "this" {
   ftp_publish_basic_authentication_enabled       = var.ftp_publish_basic_authentication_enabled
   webdeploy_publish_basic_authentication_enabled = var.webdeploy_publish_basic_authentication_enabled
 
-  builtin_logging_enabled = false
+  builtin_logging_enabled = local.builtin_logging_enabled
 
   key_vault_reference_identity_id = var.key_vault_reference_identity_id
 

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 
   storage_account_name = provider::azurerm::parse_resource_id(var.storage_account_id).resource_name
 
-  # Built-in monitoring is no longer recommended. Use Application Insights instead.
+  # Built-in logging is no longer recommended. Use Application Insights instead.
   # Ref: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring#disable-built-in-logging
   builtin_logging_enabled = false
 

--- a/tests/defaults.unit.tftest.hcl
+++ b/tests/defaults.unit.tftest.hcl
@@ -39,8 +39,8 @@ run "linux_app" {
   }
 
   assert {
-    condition = azurerm_linux_function_app.this[0].builtin_logging_enabled == false
-    error_message = "Built in logging enabled on the configured storage setting"
+    condition     = azurerm_linux_function_app.this[0].builtin_logging_enabled == false
+    error_message = "Built-in logging enabled."
   }
 }
 
@@ -78,7 +78,7 @@ run "windows_app" {
   }
 
   assert {
-    condition = azurerm_windows_function_app.this[0].builtin_logging_enabled == false
-    error_message = "Built in logging enabled on the configured storage setting"
+    condition     = azurerm_windows_function_app.this[0].builtin_logging_enabled == false
+    error_message = "Built-in logging enabled."
   }
 }

--- a/tests/defaults.unit.tftest.hcl
+++ b/tests/defaults.unit.tftest.hcl
@@ -39,11 +39,6 @@ run "linux_app" {
   }
 
   assert {
-    condition     = azurerm_linux_function_app.this[0].builtin_logging_enabled == false
-    error_message = "Built-in logging enabled."
-  }
-
-  assert {
     condition     = azurerm_linux_function_app.this[0].site_config[0].http2_enabled == false
     error_message = "HTTP2 protocol enabled"
   }
@@ -61,6 +56,11 @@ run "linux_app" {
   assert {
     condition     = azurerm_linux_function_app.this[0].client_certificate_enabled == false
     error_message = "Client certificate enabled for Function App"
+  }
+
+  assert {
+    condition     = azurerm_linux_function_app.this[0].builtin_logging_enabled == false
+    error_message = "Built-in logging enabled."
   }
 }
 
@@ -98,11 +98,6 @@ run "windows_app" {
   }
 
   assert {
-    condition     = azurerm_windows_function_app.this[0].builtin_logging_enabled == false
-    error_message = "Built-in logging enabled."
-  }
-
-  assert {
     condition     = azurerm_windows_function_app.this[0].site_config[0].http2_enabled == false
     error_message = "HTTP2 protocol enabled"
   }
@@ -120,5 +115,10 @@ run "windows_app" {
   assert {
     condition     = azurerm_windows_function_app.this[0].client_certificate_enabled == false
     error_message = "Client certificate enabled for Function App"
+  }
+
+  assert {
+    condition     = azurerm_windows_function_app.this[0].builtin_logging_enabled == false
+    error_message = "Built-in logging enabled."
   }
 }


### PR DESCRIPTION
### Checklist

- [x] I've updated both the `azurerm_linux_function_app` and `azurerm_windows_function_app` resources.
