### PR TITLE
chore: update description for variable `http2_enabled`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -217,7 +217,7 @@ variable "identity_ids" {
 }
 
 variable "http2_enabled" {
-  description = "Should the HTTP2 protocol be enabled for this Function App?"
+  description = "Should the HTTP/2 protocol be enabled for this Function App?"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
This is how it's written according to https://en.wikipedia.org/wiki/HTTP/2. Looks nicer to have it correctly written 🤷 