### PR TITLE
fix: unable to connect Storage using access key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,9 @@ locals {
   is_windows   = var.kind == "Windows"
   function_app = local.is_windows ? azurerm_windows_function_app.this[0] : azurerm_linux_function_app.this[0]
 
-  storage_account_name       = provider::azurerm::parse_resource_id(var.storage_account_id).resource_name
-  storage_account_access_key = !var.storage_uses_managed_identity ? var.storage_account_access_key : null
+  storage_account_name          = provider::azurerm::parse_resource_id(var.storage_account_id).resource_name
+  storage_account_access_key    = var.storage_account_access_key
+  storage_uses_managed_identity = var.storage_uses_managed_identity == false && var.storage_account_access_key != null ? null : var.storage_uses_managed_identity
 
   # Built-in logging is no longer recommended. Use Application Insights instead.
   # Ref: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring#disable-built-in-logging
@@ -31,7 +32,7 @@ resource "azurerm_linux_function_app" "this" {
 
   storage_account_name          = local.storage_account_name
   storage_account_access_key    = local.storage_account_access_key
-  storage_uses_managed_identity = var.storage_uses_managed_identity
+  storage_uses_managed_identity = local.storage_uses_managed_identity
 
   # Enforced by Equinor policy
   https_only = true
@@ -179,7 +180,7 @@ resource "azurerm_windows_function_app" "this" {
 
   storage_account_name          = local.storage_account_name
   storage_account_access_key    = local.storage_account_access_key
-  storage_uses_managed_identity = var.storage_uses_managed_identity
+  storage_uses_managed_identity = local.storage_uses_managed_identity
 
   # Enforced by Equinor policy
   https_only = true

--- a/tests/setup-unit-tests/outputs.tf
+++ b/tests/setup-unit-tests/outputs.tf
@@ -18,6 +18,10 @@ output "storage_account_id" {
   value = "/subscriptions/${random_uuid.subscription_id.result}/resourceGroups/${local.resource_group_name}/providers/Microsoft.Storage/storageAccounts/stfunc${local.name_suffix}"
 }
 
+output "storage_account_access_key" {
+  value = "password123"
+}
+
 output "log_analytics_workspace_id" {
   value = "/subscriptions/${random_uuid.subscription_id.result}/resourceGroups/${local.resource_group_name}/providers/Microsoft.OperationalInsights/workspaces/log-${local.name_suffix}"
 }

--- a/tests/storage.unit.tftest.hcl
+++ b/tests/storage.unit.tftest.hcl
@@ -67,6 +67,67 @@ run "windows_storage_uses_managed_identity" {
   }
 }
 
+run "linux_storage_uses_managed_identity_false" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    storage_account_id            = run.setup_tests.storage_account_id
+    storage_uses_managed_identity = false
+  }
+
+  assert {
+    condition     = azurerm_linux_function_app.this[0].storage_account_access_key == null
+    error_message = "Storage account access key is not null"
+  }
+
+  assert {
+    condition     = azurerm_linux_function_app.this[0].storage_uses_managed_identity == false
+    error_message = "Storage uses managed identity when it should not"
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.this) == 0
+    error_message = "Role assignment is created at storage account when it should not"
+  }
+}
+
+run "windows_storage_uses_managed_identity_false" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    kind                       = "Windows"
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    storage_account_id            = run.setup_tests.storage_account_id
+    storage_uses_managed_identity = false
+  }
+
+  assert {
+    condition     = azurerm_windows_function_app.this[0].storage_account_access_key == null
+    error_message = "Storage account access key is not null"
+  }
+
+  assert {
+    condition     = azurerm_windows_function_app.this[0].storage_uses_managed_identity == false
+    error_message = "Storage uses managed identity when it should not"
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.this) == 0
+    error_message = "Role assignment is created at storage account when it should not"
+  }
+}
+
 run "linux_storage_account_access_key" {
   command = plan
 

--- a/tests/storage.unit.tftest.hcl
+++ b/tests/storage.unit.tftest.hcl
@@ -1,0 +1,131 @@
+mock_provider "azurerm" {}
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup-unit-tests"
+  }
+}
+
+run "linux_storage_uses_managed_identity" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    storage_account_id            = run.setup_tests.storage_account_id
+    storage_uses_managed_identity = true
+  }
+
+  assert {
+    condition     = azurerm_linux_function_app.this[0].storage_account_access_key == null
+    error_message = "Storage account access key is not null"
+  }
+
+  assert {
+    condition     = azurerm_linux_function_app.this[0].storage_uses_managed_identity == true
+    error_message = "Storage not using managed identity"
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.this) == 1
+    error_message = "Role assignment is not created at storage account"
+  }
+}
+
+run "windows_storage_uses_managed_identity" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    kind                       = "Windows"
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    storage_account_id            = run.setup_tests.storage_account_id
+    storage_uses_managed_identity = true
+  }
+
+  assert {
+    condition     = azurerm_windows_function_app.this[0].storage_account_access_key == null
+    error_message = "Storage account access key is not null"
+  }
+
+  assert {
+    condition     = azurerm_windows_function_app.this[0].storage_uses_managed_identity == true
+    error_message = "Storage not using managed identity"
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.this) == 1
+    error_message = "Role assignment is not created at storage account"
+  }
+}
+
+run "linux_storage_account_access_key" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    storage_account_id            = run.setup_tests.storage_account_id
+    storage_account_access_key    = run.setup_tests.storage_account_access_key
+    storage_uses_managed_identity = false
+  }
+
+  assert {
+    condition     = azurerm_linux_function_app.this[0].storage_account_access_key != null
+    error_message = "Storage account access key is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_function_app.this[0].storage_uses_managed_identity == null
+    error_message = "Storage uses managed identity when it should not"
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.this) == 0
+    error_message = "Role assignment is created at storage account when it should not"
+  }
+}
+
+run "windows_storage_account_access_key" {
+  command = plan
+
+  variables {
+    app_name                   = run.setup_tests.app_name
+    resource_group_name        = run.setup_tests.resource_group_name
+    location                   = run.setup_tests.location
+    kind                       = "Windows"
+    app_service_plan_id        = run.setup_tests.app_service_plan_id
+    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
+
+    storage_account_id            = run.setup_tests.storage_account_id
+    storage_account_access_key    = run.setup_tests.storage_account_access_key
+    storage_uses_managed_identity = false
+  }
+
+  assert {
+    condition     = azurerm_windows_function_app.this[0].storage_account_access_key != null
+    error_message = "Storage account access key is null"
+  }
+
+  assert {
+    condition     = azurerm_windows_function_app.this[0].storage_uses_managed_identity == null
+    error_message = "Storage uses managed identity when it should not"
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.this) == 0
+    error_message = "Role assignment is created at storage account when it should not"
+  }
+}


### PR DESCRIPTION
Fixes the following error when value of `storage_account_access_key` is `null` and `storage_uses_managed_identity` is `false`:

```console
"storage_account_access_key": conflicts with storage_uses_managed_identity
"storage_uses_managed_identity": conflicts with storage_account_access_key
```

Added relevant tests.